### PR TITLE
Merchant item update

### DIFF
--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -9,4 +9,16 @@ class Merchants::ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @merchant = Merchant.find(params[:merchant_id])
+  end
+
+  def update
+    @merchant = Merchant.find(params[:merchant_id])
+    @merchant.update(merchant_params)
+
+    redirect_to merchant_item_path
+    
+  end
+
 end

--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -11,14 +11,20 @@ class Merchants::ItemsController < ApplicationController
 
   def edit
     @merchant = Merchant.find(params[:merchant_id])
+    @item = Item.find(params[:id])
   end
 
   def update
     @merchant = Merchant.find(params[:merchant_id])
-    @merchant.update(merchant_params)
+    @item = Item.find(params[:id])
+    @item.update(item_params)
 
-    redirect_to merchant_item_path
-    
+    redirect_to merchant_item_path    
   end
 
+  private
+
+  def item_params
+    params.permit(:name, :description, :status, :unit_price)
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -18,13 +18,10 @@ class Merchant < ApplicationRecord
 
   def not_shipped_items
     # require 'pry'; binding.pry
-    # Item.joins(invoices: [:invoice_items])
-    # .select("items.*, invoices.created_at as creation_date, invoice_items.status")
-    # .where("invoice_items.status != 2")
-    # .order(:creation_date)
-    items.joins(:invoice_items)
+    self.invoices.joins(:invoice_items)
     .where("invoice_items.status != 2")
-    .order('invoice_items.created_at ASC')
+    .order(:created_at)
+    .group(:id)
   end
 
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -18,10 +18,13 @@ class Merchant < ApplicationRecord
 
   def not_shipped_items
     # require 'pry'; binding.pry
-    Item.joins(invoices: [:invoice_items])
-    .select("items.*, invoices.created_at as creation_date, invoice_items.status")
+    # Item.joins(invoices: [:invoice_items])
+    # .select("items.*, invoices.created_at as creation_date, invoice_items.status")
+    # .where("invoice_items.status != 2")
+    # .order(:creation_date)
+    items.joins(:invoice_items)
     .where("invoice_items.status != 2")
-    .order(:creation_date)
+    .order('invoice_items.created_at ASC')
   end
 
 end

--- a/app/views/merchants/items/edit.html.erb
+++ b/app/views/merchants/items/edit.html.erb
@@ -1,0 +1,10 @@
+<h1> Item Update Page </h1>
+<%= form_with url: "/merchants/#{@merchant.id}/items/#{@item.id}", method: :patch, local: true do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.label :description %>
+  <%= f.text_area :description %>
+  <%= f.label :unit_price %>
+  <%= f.number_field :unit_price %>
+  <%= f.submit "Update Item" %>
+<% end %>

--- a/app/views/merchants/items/show.html.erb
+++ b/app/views/merchants/items/show.html.erb
@@ -1,5 +1,5 @@
 <h2> <%= @merchant.name %> </h2>
 
-<%= @item.name %>
-<%= @item.description %>
+<h3><%= @item.name %></h3>
+<p>Desciption: <%= @item.description %></p>
 <%= @item.unit_price %>

--- a/app/views/merchants/items/show.html.erb
+++ b/app/views/merchants/items/show.html.erb
@@ -2,4 +2,5 @@
 
 <h3><%= @item.name %></h3>
 <p>Desciption: <%= @item.description %></p>
-<%= @item.unit_price %>
+<p>Current Price: <%= @item.unit_price %> </p>
+<%= button_to 'Update Item', "/merchants/#{@merchant.id}/items/#{@item.id}/edit", method: :get %>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -11,8 +11,9 @@
 
 <h2> Items Ready to Ship </h2>
 
-<% @merchant.not_shipped_items.each do |item| %>
- <p> <%= item.name %> - Invoice # 
- <%= link_to "#{item.invoices.first.id}", "/merchants/#{@merchant.id}/invoices/#{item.invoices.first.id}"%> 
- - <%= item.invoices.first.created_at.strftime("%A, %B %e, %Y") %> </p>
+<% @merchant.not_shipped_items.each do |invoice| %>
+<% invoice.items.each do |item| %>
+<p> <%= item.name %> - Invoice # <%= link_to "#{invoice.id}", "/merchants/#{@merchant.id}/invoices/#{invoice.id}"%>
+ - <%= invoice.created_at.strftime("%A, %B %e, %Y") %> </p>
+ <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   get "/merchants/:id/dashboard", to: "merchants#show"
 
   resources :merchants, only: [:show] do
-    resources :items, only: [:index, :show], controller: "merchants/items"
+    resources :items, only: [:index, :show, :edit, :update], controller: "merchants/items"
   end
 
   get "/admin", to: "admin#index"

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "/admin", type: :feature do
     
     it "should display links to admin/merchants, admin/invoices, and admin/dashboard" do
       visit admin_path
-      require 'pry'; binding.pry
+
       
       expect(page).to have_link("Dashboard", :href => admin_path)
       expect(page).to have_link("Merchants", :href => admin_merchants_path)

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "Merchant Dashboard" do
     let!(:merchant) { create(:merchant, id: 1, name:"Dealer of Death", status: 1 )}
     let!(:merchant2) { create(:merchant, id: 2, name:"Dealer of Life", status: 1 )}
 
-
     let!(:item1) { create(:item, id: 1, merchant_id: 1 )}
     let!(:item2) { create(:item, id: 2, merchant_id: 1 )}
     let!(:item3) { create(:item, id: 3, merchant_id: 1 )}
@@ -14,8 +13,8 @@ RSpec.describe "Merchant Dashboard" do
     let!(:item6) { create(:item, id: 6, merchant_id: 1 )}
     let!(:item7) { create(:item, id: 7, merchant_id: 1 )}
 
-    let!(:item1) { create(:item, id: 1, merchant_id: 2 )}
-    let!(:item2) { create(:item, id: 2, merchant_id: 2 )}
+    let!(:item8) { create(:item, id: 8, merchant_id: 2 )}
+    let!(:item9) { create(:item, id: 9, merchant_id: 2 )}
 
     let!(:customer1) { create(:customer, id: 1, first_name: "Austin" )}
     let!(:customer2) { create(:customer, id: 2, first_name: "Jimmy" )}
@@ -115,8 +114,6 @@ RSpec.describe "Merchant Dashboard" do
       expect(customer1.first_name).to appear_before(customer3.first_name)
       expect(customer3.first_name).to appear_before(customer4.first_name)
       expect(customer4.first_name).to appear_before(customer5.first_name)
-      # expect(page).to_not have_content(customer6.first_name)
-      # expect(page).to_not have_content(customer7.first_name)
     end
 
     it "displays the number of successful transactions next to customer's name" do
@@ -151,19 +148,25 @@ RSpec.describe "Merchant Dashboard" do
       expect(page).to_not have_content(invoice_item12.item.name)
       expect(page).to_not have_content(invoice_item16.item.name)
 
-      # expect(page).to have_link("/merchants/#{merchant.id}/invoices/#{item1.invoice_items.first.invoice.id}")
       expect(page).to have_content("#{item1.invoice_items.first.invoice.id}")
       expect(page).to have_content("#{item2.invoice_items.first.invoice.id}")
       expect(page).to have_content("#{item3.invoice_items.first.invoice.id}")
       expect(page).to have_content("#{item5.invoice_items.first.invoice.id}")
-
-      # expect(page).to_not have_content("#{item7.invoice_items.first.invoice.id}")
+      # refactor within blocks so we can test not_have content
     end
 
     it "displays Invoices sorted by least recent with date next to ID " do
       visit "/merchants/#{merchant.id}/dashboard"
 
-      save_and_open_page
+      expect("Wednesday, January 25, 2012").to appear_before("Sunday, March 25, 2012")
+      expect("Sunday, March 25, 2012").to appear_before("Wednesday, April 25, 2012")
+      expect("Wednesday, April 25, 2012").to appear_before("Friday, May 25, 2012")
+      expect("Friday, May 25, 2012").to appear_before("Wednesday, June 20, 2012")
+      expect("Wednesday, June 20, 2012").to appear_before("Wednesday, July 25, 2012")
+      expect("Wednesday, July 25, 2012").to appear_before("Saturday, August 25, 2012")
+      expect("Saturday, August 25, 2012").to appear_before("Sunday, November 25, 2012")
+      expect("Sunday, November 25, 2012").to appear_before("Monday, March 25, 2013")
+      expect("Monday, March 25, 2013").to appear_before("Wednesday, December 25, 2013")
     end
   end
 end

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -123,15 +123,15 @@ RSpec.describe 'Merchant Items Show Page' do
       expect(page).to have_button("Update Item")
       click_button("Update Item")
 
-      # current_path("/merchants/#{merchant.id}/items/#{item1.id}/edit")
+      expect(current_path).to eq("/merchants/#{merchant.id}/items/#{item1.id}/edit")
 
       fill_in(:name, with: "Frieza Pod")
       fill_in(:description, with: "floating, egg-shaped vehicle.")
       fill_in(:unit_price, with: 19990)
       click_button("Update Item")
 
-      # current_path "/merchants/#{merchant.id}/items/#{item1.id}/edit" 
-# save_and_open_page
+      expect(current_path).to eq("/merchants/#{merchant.id}/items/#{item1.id}")
+
       expect(page).to have_content("Frieza Pod")
       expect(page).to have_content("floating, egg-shaped vehicle.")
       expect(page).to have_content(19990)

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -120,21 +120,21 @@ RSpec.describe 'Merchant Items Show Page' do
     it "displays a link to update the item information" do
       visit "/merchants/#{merchant.id}/items/#{item1.id}"
 
-      expect(page).to have_link("Update Item")
+      expect(page).to have_button("Update Item")
       click_button("Update Item")
 
       current_path("/merchants/#{merchant.id}/items/#{item1.id}/edit")
 
       fill_in(:name, with: "Frieza Pod")
-      fill_in(:description, with: "a floating, egg-shaped vehicle.")
+      fill_in(:description, with: "floating, egg-shaped vehicle.")
       fill_in(:unit_price, with: 19990)
       click_button("Update Item")
 
       current_path("/merchants/#{merchant.id}/items/#{item1.id}")
 
       expect(page).to have_content("Frieza Pod")
-      expect(page).to have_content("Frieza Pod")
-      expect(page).to have_content("Frieza Pod")
+      expect(page).to have_content("floating, egg-shaped vehicle.")
+      expect(page).to have_content(19990)
 
     end
   end

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -123,15 +123,15 @@ RSpec.describe 'Merchant Items Show Page' do
       expect(page).to have_button("Update Item")
       click_button("Update Item")
 
-      current_path("/merchants/#{merchant.id}/items/#{item1.id}/edit")
+      # current_path("/merchants/#{merchant.id}/items/#{item1.id}/edit")
 
       fill_in(:name, with: "Frieza Pod")
       fill_in(:description, with: "floating, egg-shaped vehicle.")
       fill_in(:unit_price, with: 19990)
       click_button("Update Item")
 
-      current_path("/merchants/#{merchant.id}/items/#{item1.id}")
-
+      # current_path "/merchants/#{merchant.id}/items/#{item1.id}/edit" 
+# save_and_open_page
       expect(page).to have_content("Frieza Pod")
       expect(page).to have_content("floating, egg-shaped vehicle.")
       expect(page).to have_content(19990)

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -116,5 +116,26 @@ RSpec.describe 'Merchant Items Show Page' do
       expect(page).to_not have_content(item3.name)
       expect(page).to_not have_content(item3.unit_price)
     end
+
+    it "displays a link to update the item information" do
+      visit "/merchants/#{merchant.id}/items/#{item1.id}"
+
+      expect(page).to have_link("Update Item")
+      click_button("Update Item")
+
+      current_path("/merchants/#{merchant.id}/items/#{item1.id}/edit")
+
+      fill_in(:name, with: "Frieza Pod")
+      fill_in(:description, with: "a floating, egg-shaped vehicle.")
+      fill_in(:unit_price, with: 19990)
+      click_button("Update Item")
+
+      current_path("/merchants/#{merchant.id}/items/#{item1.id}")
+
+      expect(page).to have_content("Frieza Pod")
+      expect(page).to have_content("Frieza Pod")
+      expect(page).to have_content("Frieza Pod")
+
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -8,4 +8,42 @@ RSpec.describe Merchant, type: :model do
     it { should have_many(:customers).through(:invoices) }
     it { should have_many(:transactions).through(:invoices) }
   end
+
+  describe "instance methods" do 
+    let!(:merchant) { create(:merchant, name:"Dealer of Death", status: 1 )}
+    let!(:merchant2) { create(:merchant, name:"Dealer of Life", status: 1 )}
+
+    let!(:items_m1) { create_list(:item, 5, merchant_id: merchant.id)}
+    let!(:items_m2) { create_list(:item, 5, merchant_id: merchant2.id)}
+
+    let!(:customer1) { create(:customer, first_name: "Austin" )}
+    let!(:customer2) { create(:customer, first_name: "Jimmy" )}
+
+    let!(:invoice1) { create(:invoice, id: 1, created_at: "2012-03-25 09:54:09 UTC", customer_id: customer1.id )}
+    let!(:invoice2) { create(:invoice, id: 2, created_at: "2012-05-25 09:54:09 UTC", customer_id: customer1.id )}
+    let!(:invoice3) { create(:invoice, id: 3, created_at: "2012-07-25 09:54:09 UTC", customer_id: customer1.id )}
+    let!(:invoice4) { create(:invoice, id: 4, created_at: "2012-09-25 09:54:09 UTC", customer_id: customer1.id )}
+
+    let!(:invoice5) { create(:invoice, id: 5, created_at: "2013-03-25 09:54:09 UTC", customer_id: customer2.id )}
+    let!(:invoice6) { create(:invoice, id: 6, created_at: "2013-05-25 09:54:09 UTC", customer_id: customer2.id )}
+    let!(:invoice7) { create(:invoice, id: 7, created_at: "2013-06-25 09:54:09 UTC", customer_id: customer2.id )}
+    let!(:invoice8) { create(:invoice, id: 8, created_at: "2013-12-25 09:54:09 UTC", customer_id: customer2.id )}
+
+    let!(:invoice_item1) { create(:invoice_item, id: 1, status: 0, item_id: items_m1[1].id, invoice_id: invoice1.id )}
+    let!(:invoice_item2) { create(:invoice_item, id: 2, status: 1, item_id: items_m1[4].id, invoice_id: invoice2.id )}
+    let!(:invoice_item3) { create(:invoice_item, id: 3, status: 1, item_id: items_m1[3].id, invoice_id: invoice3.id )}
+    let!(:invoice_item4) { create(:invoice_item, id: 4, status: 2, item_id: items_m1[2].id, invoice_id: invoice4.id )}
+
+    let!(:invoice_item5) { create(:invoice_item, id: 5, status: 0, item_id: items_m2[0].id, invoice_id: invoice5.id )}
+    let!(:invoice_item6) { create(:invoice_item, id: 6, status: 2, item_id: items_m2[2].id, invoice_id: invoice6.id )}
+    let!(:invoice_item7) { create(:invoice_item, id: 7, status: 2, item_id: items_m2[4].id, invoice_id: invoice7.id )}
+    let!(:invoice_item8) { create(:invoice_item, id: 8, status: 1, item_id: items_m2[3].id, invoice_id: invoice8.id )}
+
+    describe "#not_shipped_items" do 
+      it "displays the not yet shipped items ordered by least recent invoice creation date" do
+        expect(merchant.not_shipped_items).to eq([invoice1, invoice2, invoice3])
+        expect(merchant2.not_shipped_items).to eq([invoice5, invoice8])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds updates to show spec test with before and after results on the item show page
updates item show page to have update button
updates to routes to include edit and update actions
updates controllers with edit and update actions
creates edit view
spec test passing pending the addition of the current_path test not passing. Clean up when refactor routes.